### PR TITLE
Improve scroll stability on ACT1025: prebuffer loop + BLE guardrails

### DIFF
--- a/bk_light/display_session.py
+++ b/bk_light/display_session.py
@@ -113,6 +113,7 @@ class BleDisplaySession:
         self.scan_timeout = scan_timeout
         self.client: Optional[BleakClient] = None
         self.watcher = AckWatcher(log_notifications)
+        self._handshake_primed = False
 
     async def _safe_disconnect(self) -> None:
         if self.client is None:
@@ -169,6 +170,7 @@ class BleDisplaySession:
                     except Exception:
                         pass
                 await self.client.start_notify(UUID_NOTIFY, self.watcher.handler)
+                self._handshake_primed = False
                 return
             except Exception as error:
                 if not self.auto_reconnect or attempt > self.max_retries:
@@ -199,22 +201,26 @@ class BleDisplaySession:
             try:
                 await self._ensure_connected()
                 self.watcher.reset()
-                await self.client.write_gatt_char(UUID_WRITE, HANDSHAKE_FIRST, response=False)
-                await wait_for_ack(self.watcher.stage_one, "HANDSHAKE_STAGE_ONE", self.log_notifications)
-                await asyncio.sleep(delay)
-                self.watcher.stage_two.clear()
-                skip_stage_two = False
-                try:
-                    await self.client.write_gatt_char(UUID_WRITE, HANDSHAKE_SECOND, response=False)
-                    await wait_for_ack(self.watcher.stage_two, "HANDSHAKE_STAGE_TWO", self.log_notifications)
-                except asyncio.TimeoutError:
-                    skip_stage_two = True
-                    if self.log_notifications:
-                        print("HANDSHAKE_STAGE_TWO_SKIPPED")
-                else:
+
+                if not self._handshake_primed:
+                    await self.client.write_gatt_char(UUID_WRITE, HANDSHAKE_FIRST, response=False)
+                    await wait_for_ack(self.watcher.stage_one, "HANDSHAKE_STAGE_ONE", self.log_notifications)
                     await asyncio.sleep(delay)
-                if skip_stage_two:
-                    await asyncio.sleep(delay)
+                    self.watcher.stage_two.clear()
+                    skip_stage_two = False
+                    try:
+                        await self.client.write_gatt_char(UUID_WRITE, HANDSHAKE_SECOND, response=False)
+                        await wait_for_ack(self.watcher.stage_two, "HANDSHAKE_STAGE_TWO", self.log_notifications)
+                    except asyncio.TimeoutError:
+                        skip_stage_two = True
+                        if self.log_notifications:
+                            print("HANDSHAKE_STAGE_TWO_SKIPPED")
+                    else:
+                        await asyncio.sleep(delay)
+                    if skip_stage_two:
+                        await asyncio.sleep(delay)
+                    self._handshake_primed = True
+
                 # Keep acknowledged write for frame payload: slower but much more stable on ACT1025.
                 await self.client.write_gatt_char(UUID_WRITE, frame, response=True)
                 await wait_for_ack(self.watcher.stage_three, "FRAME_ACK", self.log_notifications)
@@ -222,12 +228,15 @@ class BleDisplaySession:
                 # await self.client.write_gatt_char(UUID_WRITE, FRAME_VALIDATION, response=False)
                 return
             except (asyncio.TimeoutError, BleakError, ConnectionError) as error:
+                # Force full handshake path on next retry.
+                self._handshake_primed = False
                 if not self.auto_reconnect or attempt > self.max_retries:
                     await self._safe_disconnect()
                     raise error
                 await self._safe_disconnect()
                 await asyncio.sleep(self.reconnect_delay)
             except Exception as error:
+                self._handshake_primed = False
                 if not self.auto_reconnect or attempt > self.max_retries:
                     await self._safe_disconnect()
                     raise error

--- a/bk_light/display_session.py
+++ b/bk_light/display_session.py
@@ -114,6 +114,8 @@ class BleDisplaySession:
         self.client: Optional[BleakClient] = None
         self.watcher = AckWatcher(log_notifications)
         self._handshake_primed = False
+        self._frames_since_validation = 0
+        self._validation_every = 30
 
     async def _safe_disconnect(self) -> None:
         if self.client is None:
@@ -224,12 +226,16 @@ class BleDisplaySession:
                 # Keep acknowledged write for frame payload: slower but much more stable on ACT1025.
                 await self.client.write_gatt_char(UUID_WRITE, frame, response=True)
                 await wait_for_ack(self.watcher.stage_three, "FRAME_ACK", self.log_notifications)
+                self._frames_since_validation += 1
+                if self._frames_since_validation >= self._validation_every:
+                    await self.client.write_gatt_char(UUID_WRITE, FRAME_VALIDATION, response=False)
+                    self._frames_since_validation = 0
                 await asyncio.sleep(delay)
-                # await self.client.write_gatt_char(UUID_WRITE, FRAME_VALIDATION, response=False)
                 return
             except (asyncio.TimeoutError, BleakError, ConnectionError) as error:
                 # Force full handshake path on next retry.
                 self._handshake_primed = False
+                self._frames_since_validation = 0
                 if not self.auto_reconnect or attempt > self.max_retries:
                     await self._safe_disconnect()
                     raise error

--- a/bk_light/display_session.py
+++ b/bk_light/display_session.py
@@ -215,7 +215,8 @@ class BleDisplaySession:
                     await asyncio.sleep(delay)
                 if skip_stage_two:
                     await asyncio.sleep(delay)
-                await self.client.write_gatt_char(UUID_WRITE, frame, response=True)
+                # Use write-without-response for frame payload to reduce BLE latency/jitter.
+                await self.client.write_gatt_char(UUID_WRITE, frame, response=False)
                 await wait_for_ack(self.watcher.stage_three, "FRAME_ACK", self.log_notifications)
                 await asyncio.sleep(delay)
                 # await self.client.write_gatt_char(UUID_WRITE, FRAME_VALIDATION, response=False)

--- a/bk_light/display_session.py
+++ b/bk_light/display_session.py
@@ -215,8 +215,8 @@ class BleDisplaySession:
                     await asyncio.sleep(delay)
                 if skip_stage_two:
                     await asyncio.sleep(delay)
-                # Use write-without-response for frame payload to reduce BLE latency/jitter.
-                await self.client.write_gatt_char(UUID_WRITE, frame, response=False)
+                # Keep acknowledged write for frame payload: slower but much more stable on ACT1025.
+                await self.client.write_gatt_char(UUID_WRITE, frame, response=True)
                 await wait_for_ack(self.watcher.stage_three, "FRAME_ACK", self.log_notifications)
                 await asyncio.sleep(delay)
                 # await self.client.write_gatt_char(UUID_WRITE, FRAME_VALIDATION, response=False)

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ device:
   reconnect_delay: 2.0
   mtu: 2048
   rotate: 0
-  brightness: 0.15
+  brightness: 0.65
   timezone: auto
   scan_timeout: 6.0
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,20 +1,20 @@
 device:
-  address: "31:C3:BD:32:14:7A"
+  address: "F0:27:3C:1A:8B:C3"
   auto_reconnect: true
   reconnect_delay: 2.0
   mtu: 2048
   rotate: 0
-  brightness: 0.65
+  brightness: 0.15
   timezone: auto
   scan_timeout: 6.0
 
 panels:
-  tile_width: 64
-  tile_height: 16
+  tile_width: 32
+  tile_height: 32
   layout:
     columns: 1
     rows: 1
-  list: ["31:C3:BD:32:14:7A"]
+  list: ["F0:27:3C:1A:8B:C3"]
 
 display:
   frame_interval: 0.05

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 device:
-  address: "F0:27:3C:1A:8B:C3"
+  address: "31:C3:BD:32:14:7A"
   auto_reconnect: true
   reconnect_delay: 2.0
   mtu: 2048
@@ -9,12 +9,12 @@ device:
   scan_timeout: 6.0
 
 panels:
-  tile_width: 32
-  tile_height: 32
+  tile_width: 64
+  tile_height: 16
   layout:
     columns: 1
     rows: 1
-  list: ["F0:27:3C:1A:8B:C3"]
+  list: ["31:C3:BD:32:14:7A"]
 
 display:
   frame_interval: 0.05

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -128,8 +128,8 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                         offset_y_base,
                         position,
                     )
-                    # Lower transport delay to reduce per-frame latency.
-                    await manager.send_image(frame, delay=0.0)
+                    # Small transport delay avoids overdriving BLE writes (reduces end-of-run freezes).
+                    await manager.send_image(frame, delay=0.01)
                     position = (position + step) % strip_width
 
                     # Target a steady frame cadence while avoiding busy loops.

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -128,7 +128,7 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                     position = (position + step) % strip_width
             else:
                 # Auto-fit static text so it doesn't clip on small displays (e.g. 64x16)
-                while text_bitmap.width > (canvas[0] - 2) and size > 8:
+                while text_bitmap.width > (canvas[0] - 2) and size > 11:
                     size -= 1
                     text_bitmap = build_text_bitmap(
                         message,

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -101,12 +101,16 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
             if preset.mode == "scroll":
                 gap_override = overrides.get("gap")
                 base_gap = gap_override if gap_override is not None else preset.gap
-                gap = int(base_gap) if base_gap is not None else 0
+                gap = int(base_gap) if base_gap is not None else 16
                 strip_width = max(1, text_bitmap.width + gap)
                 step_override = overrides.get("step")
                 base_step = step_override if step_override is not None else preset.step
                 step_value = int(base_step) if base_step is not None else 1
                 step = max(1, step_value)
+                interval_override = overrides.get("interval")
+                interval = float(interval_override) if interval_override is not None else float(preset.interval)
+                if interval <= 0:
+                    interval = 0.02
                 position = 0
                 while True:
                     frame = render_scroll_frame(
@@ -120,9 +124,21 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                         position,
                     )
                     await manager.send_image(frame, delay=0.0)
-                    await asyncio.sleep(max(0.0, float(preset.interval)))
+                    await asyncio.sleep(interval)
                     position = (position + step) % strip_width
             else:
+                # Auto-fit static text so it doesn't clip on small displays (e.g. 64x16)
+                while text_bitmap.width > (canvas[0] - 2) and size > 8:
+                    size -= 1
+                    text_bitmap = build_text_bitmap(
+                        message,
+                        font_path,
+                        size,
+                        spacing,
+                        color,
+                        config.display.antialias_text,
+                        monospace_digits=True,
+                    )
                 frame = render_static_frame(
                     canvas,
                     text_bitmap,
@@ -130,8 +146,8 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                     offset_x_base,
                     offset_y_base,
                 )
-                await manager.send_image(frame, delay=0.15)
-                await asyncio.sleep(0.2)
+                await manager.send_image(frame, delay=0.0)
+                await asyncio.sleep(0.1)
     except asyncio.CancelledError:
         raise
     except Exception as error:

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -123,8 +123,9 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                         offset_y_base,
                         position,
                     )
-                    await manager.send_image(frame, delay=0.0)
-                    await asyncio.sleep(interval)
+                    # Small BLE pacing delay drastically improves ACT1025 stability during long scroll loops.
+                    await manager.send_image(frame, delay=0.015)
+                    await asyncio.sleep(max(interval, 0.006))
                     position = (position + step) % strip_width
             else:
                 # Auto-fit static text so it doesn't clip on small displays (e.g. 64x16)

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -119,8 +119,8 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                         offset_y_base,
                         position,
                     )
-                    await manager.send_image(frame, delay=0.1)
-                    await asyncio.sleep(preset.interval)
+                    await manager.send_image(frame, delay=0.0)
+                    await asyncio.sleep(max(0.0, float(preset.interval)))
                     position = (position + step) % strip_width
             else:
                 frame = render_static_frame(

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -96,38 +96,48 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
     offset_x_base = preset.offset_x + profile.offset_x
     offset_y_base = preset.offset_y + profile.offset_y
     try:
-        async with PanelManager(config) as manager:
-            canvas = manager.canvas_size
-            if preset.mode == "scroll":
-                gap_override = overrides.get("gap")
-                base_gap = gap_override if gap_override is not None else preset.gap
-                gap = int(base_gap) if base_gap is not None else 16
-                strip_width = max(1, text_bitmap.width + gap)
-                step_override = overrides.get("step")
-                base_step = step_override if step_override is not None else preset.step
-                step_value = int(base_step) if base_step is not None else 1
-                step = max(1, step_value)
-                interval_override = overrides.get("interval")
-                interval = float(interval_override) if interval_override is not None else float(preset.interval)
-                if interval <= 0:
-                    interval = 0.02
-                position = 0
-                while True:
-                    frame = render_scroll_frame(
-                        canvas,
-                        text_bitmap,
-                        background,
-                        preset.direction,
-                        gap,
-                        offset_x_base,
-                        offset_y_base,
-                        position,
-                    )
-                    # Small BLE pacing delay drastically improves ACT1025 stability during long scroll loops.
-                    await manager.send_image(frame, delay=0.015)
-                    await asyncio.sleep(max(interval, 0.006))
-                    position = (position + step) % strip_width
-            else:
+        if preset.mode == "scroll":
+            gap_override = overrides.get("gap")
+            base_gap = gap_override if gap_override is not None else preset.gap
+            gap = int(base_gap) if base_gap is not None else 16
+            strip_width = max(1, text_bitmap.width + gap)
+            step_override = overrides.get("step")
+            base_step = step_override if step_override is not None else preset.step
+            step_value = int(base_step) if base_step is not None else 1
+            step = max(1, step_value)
+            interval_override = overrides.get("interval")
+            interval = float(interval_override) if interval_override is not None else float(preset.interval)
+            if interval <= 0:
+                interval = 0.02
+            interval = max(interval, 0.008)
+
+            # Hardening: force periodic reconnects to avoid long-lived BLE scroll sessions freezing ACT1025.
+            frames_per_session = 120
+            reconnect_pause = 0.12
+            position = 0
+            while True:
+                async with PanelManager(config) as manager:
+                    canvas = manager.canvas_size
+                    sent = 0
+                    while sent < frames_per_session:
+                        frame = render_scroll_frame(
+                            canvas,
+                            text_bitmap,
+                            background,
+                            preset.direction,
+                            gap,
+                            offset_x_base,
+                            offset_y_base,
+                            position,
+                        )
+                        await manager.send_image(frame, delay=0.02)
+                        await asyncio.sleep(interval)
+                        position = (position + step) % strip_width
+                        sent += 1
+                await asyncio.sleep(reconnect_pause)
+        else:
+            async with PanelManager(config) as manager:
+                canvas = manager.canvas_size
                 # Auto-fit static text so it doesn't clip on small displays (e.g. 64x16)
                 while text_bitmap.width > (canvas[0] - 2) and size > 11:
                     size -= 1

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -159,11 +159,18 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                     step,
                 )
                 frame_index = 0
+                loop_guard_counter = 0
                 while True:
                     frame = frames[frame_index]
                     # Small transport delay avoids overdriving BLE writes (reduces end-of-run freezes).
                     await manager.send_image(frame, delay=0.01)
                     frame_index = (frame_index + 1) % len(frames)
+
+                    # Guardrail: brief pause at full-cycle boundaries helps avoid firmware lockups.
+                    if frame_index == 0:
+                        loop_guard_counter += 1
+                        if loop_guard_counter % 1 == 0:
+                            await asyncio.sleep(0.04)
 
                     # Target a steady frame cadence while avoiding busy loops.
                     next_tick += interval

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -111,30 +111,35 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
                 interval = 0.02
             interval = max(interval, 0.008)
 
-            # Hardening: force periodic reconnects to avoid long-lived BLE scroll sessions freezing ACT1025.
-            frames_per_session = 120
-            reconnect_pause = 0.12
+            # Keep a persistent BLE session for smooth scrolling.
+            # Periodic reconnects introduce visible freezes on ACT1025.
             position = 0
-            while True:
-                async with PanelManager(config) as manager:
-                    canvas = manager.canvas_size
-                    sent = 0
-                    while sent < frames_per_session:
-                        frame = render_scroll_frame(
-                            canvas,
-                            text_bitmap,
-                            background,
-                            preset.direction,
-                            gap,
-                            offset_x_base,
-                            offset_y_base,
-                            position,
-                        )
-                        await manager.send_image(frame, delay=0.02)
-                        await asyncio.sleep(interval)
-                        position = (position + step) % strip_width
-                        sent += 1
-                await asyncio.sleep(reconnect_pause)
+            next_tick = asyncio.get_running_loop().time()
+            async with PanelManager(config) as manager:
+                canvas = manager.canvas_size
+                while True:
+                    frame = render_scroll_frame(
+                        canvas,
+                        text_bitmap,
+                        background,
+                        preset.direction,
+                        gap,
+                        offset_x_base,
+                        offset_y_base,
+                        position,
+                    )
+                    # Lower transport delay to reduce per-frame latency.
+                    await manager.send_image(frame, delay=0.0)
+                    position = (position + step) % strip_width
+
+                    # Target a steady frame cadence while avoiding busy loops.
+                    next_tick += interval
+                    sleep_for = next_tick - asyncio.get_running_loop().time()
+                    if sleep_for > 0:
+                        await asyncio.sleep(sleep_for)
+                    else:
+                        # If BLE is slower than target cadence, resync to 'now'.
+                        next_tick = asyncio.get_running_loop().time()
         else:
             async with PanelManager(config) as manager:
                 canvas = manager.canvas_size

--- a/scripts/display_text.py
+++ b/scripts/display_text.py
@@ -68,6 +68,36 @@ def render_scroll_frame(
     return frame.convert("RGB")
 
 
+def precompute_scroll_frames(
+    canvas: tuple[int, int],
+    text_bitmap: Image.Image,
+    background: tuple[int, int, int],
+    direction: str,
+    gap: int,
+    offset_x: int,
+    offset_y: int,
+    step: int,
+) -> list[Image.Image]:
+    strip_width = max(1, text_bitmap.width + gap)
+    frame_positions = list(range(0, strip_width, max(1, step)))
+    if not frame_positions:
+        frame_positions = [0]
+    frames: list[Image.Image] = []
+    for position in frame_positions:
+        frames.append(
+            render_scroll_frame(
+                canvas,
+                text_bitmap,
+                background,
+                direction,
+                gap,
+                offset_x,
+                offset_y,
+                position,
+            )
+        )
+    return frames
+
 async def display_text(config: AppConfig, message: str, preset_name: str, overrides: dict[str, Optional[str]]) -> None:
     preset = text_options(config, preset_name, overrides)
     color = parse_color(overrides.get("color")) or parse_color(preset.color)
@@ -113,24 +143,27 @@ async def display_text(config: AppConfig, message: str, preset_name: str, overri
 
             # Keep a persistent BLE session for smooth scrolling.
             # Periodic reconnects introduce visible freezes on ACT1025.
-            position = 0
             next_tick = asyncio.get_running_loop().time()
             async with PanelManager(config) as manager:
                 canvas = manager.canvas_size
+                # Build one full animation cycle once, then replay it in a loop.
+                # This removes per-frame rasterization jitter and mimics an "array of frames" pipeline.
+                frames = precompute_scroll_frames(
+                    canvas,
+                    text_bitmap,
+                    background,
+                    preset.direction,
+                    gap,
+                    offset_x_base,
+                    offset_y_base,
+                    step,
+                )
+                frame_index = 0
                 while True:
-                    frame = render_scroll_frame(
-                        canvas,
-                        text_bitmap,
-                        background,
-                        preset.direction,
-                        gap,
-                        offset_x_base,
-                        offset_y_base,
-                        position,
-                    )
+                    frame = frames[frame_index]
                     # Small transport delay avoids overdriving BLE writes (reduces end-of-run freezes).
                     await manager.send_image(frame, delay=0.01)
-                    position = (position + step) % strip_width
+                    frame_index = (frame_index + 1) % len(frames)
 
                     # Target a steady frame cadence while avoiding busy loops.
                     next_tick += interval


### PR DESCRIPTION
## Summary

This PR improves text scroll stability for ACT1025 (64x16) panels on Linux/BLE by reducing per-frame overhead and adding transport guardrails.

## What changed

- Precompute one full scroll cycle once, then replay it in a loop (instead of re-rendering every frame).
- Reuse BLE handshake state across frames on the same connection (reset on errors/reconnect).
- Add periodic `FRAME_VALIDATION` writes during sustained scrolling.
- Add a small boundary pause at loop wrap to reduce firmware lockups.

## Why

The previous implementation streamed frames continuously with heavy per-frame work and repeated BLE control overhead, which could lead to choppy scrolling and panel freezes.

## Observed result on ACT1025

- Smoothness improved.
- Freeze still occurs under long sustained scroll, but later than before (more loops before lockup).

So this is an incremental stability improvement, not a complete fix.